### PR TITLE
7-day average new cases and new deaths

### DIFF
--- a/R/calc_riskmatrix.R
+++ b/R/calc_riskmatrix.R
@@ -23,6 +23,8 @@ calc_add_risk <- function(df){
     dplyr::group_by(source, id) %>%
     dplyr::arrange(date) %>%
     dplyr::mutate(weekdate              = lubridate::floor_date(date, "week", week_start = 1),
+                  new_cases_7dav        = zoo::rollmean(new_cases, k = 7, fill = 0, align = "right"),
+                  new_deaths_7dav       = zoo::rollmean(new_deaths, k = 7, fill = 0, align = "right"),
                   daily_case_incidence  = dplyr::if_else(population > 0, ((new_cases_copy/population)) * 100000,  NA_real_),
                   daily_death_incidence = dplyr::if_else(population > 0, ((new_deaths_copy/population)) * 100000, NA_real_),
                   week_case             = cumulative_cases_copy - dplyr::lag(cumulative_cases_copy, 7),

--- a/R/viz_tables.R
+++ b/R/viz_tables.R
@@ -20,11 +20,11 @@ table_countriesofconcern <- function(df_risk, df_vaccinations, df_vaccinations_m
         dplyr::ungroup() %>%
         dplyr::mutate(Country                                   = country,
                       Date                                      = date,
-                      `New Cases (Incidence per 100,000)`       = paste0(comma(round(new_cases)), " (", round(week_case_incidence, 2),")"),
+                      `New Cases (Incidence per 100,000)`       = paste0(comma(round(new_cases_7dav)), " (", round(week_case_incidence, 2),")"),
                       `7 Day Cases`                             = scales::comma(round(week_case)),
                       `Previous 7 Day Cases`                    = scales::comma(round(prev_week_case)),
                       `% Change in Cases from Previous 7 Days`  = scales::percent(percent_change_case, scale = 1),
-                      `New Deaths (Incidence per 100,000)`      = paste0(comma(round(new_deaths)), " (", round(week_death_incidence, 2),")"),
+                      `New Deaths (Incidence per 100,000)`      = paste0(comma(round(new_deaths_7dav)), " (", round(week_death_incidence, 2),")"),
                       `7 Day Deaths`                            = scales::comma(round(week_death)),
                       `Previous 7 Day Deaths`                   = scales::comma(round(prev_week_death)),
                       `% Change in Deaths from Previous 7 Days` = scales::percent(percent_change_death, scale = 1)) %>%


### PR DESCRIPTION
- Add two 7-day average columns to df in calc_riskmatrix for new cases (new_cases_7dav) and new deaths (new_deaths_7dav).
- In the countries of concern table, change new cases and new deaths to 7-day averages.